### PR TITLE
Remove filetype=ruby comments to use Crystal syntax

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,3 +1,2 @@
-# vim: filetype=ruby
 require "spec"
 require "../src/tucson"

--- a/spec/tucson_spec.cr
+++ b/spec/tucson_spec.cr
@@ -1,4 +1,3 @@
-# vim: filetype=ruby
 require "./spec_helper"
 require "../src/tucson"
 

--- a/src/tucson.cr
+++ b/src/tucson.cr
@@ -1,5 +1,3 @@
-# vim: filetype=ruby
-
 module Tucson
   VERSION = "0.1.0"
 


### PR DESCRIPTION
### What

Remove the comment telling `vim` to use Ruby syntax.

### Why

With [`crystal-vim`](https://github.com/vim-crystal/vim-crystal) the syntax for Crystal will be used automatically.